### PR TITLE
docs: add details to install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,18 @@
 This is to serve as a starting template for Sparkbox Drupal projects.
 
 ## Requirements
+You should have these installed on your machine before starting the installation instructions.
+
 - [Docker](https://www.docker.com/)
-- [Docker Compose](https://docs.docker.com/compose/install/) ( Should be installed with Docker)
-- `.env` see `.env.example`
+- [Docker Compose](https://docs.docker.com/compose/install/) (Should be installed with Docker)
 
 ## Installation Instructions
-- clone this repo
-- cd into your new directory
-- `./drupal-install.sh`
-- `docker-compose build`
-- `docker-compose up`
-- Navigate to `localhost:8080` and follow installation prompts.
+1. Clone this repo
+1. `cd` into your new directory
+1. Create an `.env` file in the root based on the `.env.example` file
+1. Run `./drupal-install.sh` to download, extract, and move drupal to a new drupal directory
+1. Run `docker-compose build` to build the project in a docker container
+1. Run `docker-compose up` to run the container
+1. Navigate to `localhost:8080` and follow installation prompts
 
-**The `Host` is the name of your database (Named in .env).**
+**The `Host` is the name of your database (named in .env).**


### PR DESCRIPTION
Just adding some details of why/how to the readme keeping in mind that this may end up being widely used. Paul, for this PR, can you:

- [ ] Confirm that my descriptions of why we're doing things is correct
- [ ] See if there are other place we can add details (could maybe use some instruction as far as what to put in the `.env` file, even if it's just whatever they want?)